### PR TITLE
tools:  Add examples for NOLA-11 testbed.

### DIFF
--- a/tests/UnitTestBase.py
+++ b/tests/UnitTestBase.py
@@ -98,7 +98,7 @@ class UnitTestBase:
                             default = False)
         self.parser.add_argument("--force-upgrade", type=bool, help="Force upgrading firmware even if it is already current version",
                             default = False)
-        self.parser.add_argument("-m", "--model", type=str, choices=['ea8300', 'ecw5410', 'ecw5211', 'ec420', 'wf188n', 'None'],
+        self.parser.add_argument("-m", "--model", type=str, choices=['ea8300', 'ecw5410', 'ecw5211', 'ec420', 'wf188n', 'eap102', 'None'],
                             help="AP model to be run", required=True)
         self.parser.add_argument("--equipment_id", type=str,
                                  help="AP model ID, as exists in the cloud-sdk.  -1 to auto-detect.",

--- a/tools/USAGE_EXAMPLES.txt
+++ b/tools/USAGE_EXAMPLES.txt
@@ -7,6 +7,7 @@ ssh -C -L 8800:lf1:4002 -L 8801:lf1:5901 -L 8802:lf1:8080 -L 8803:lab-ctlr:22 \
        -L 8810:lf4:4002 -L 8811:lf4:5901 -L 8812:lf4:8080 -L 8813:lab-ctlr:22 \
        -L 8890:lf9:4002 -L 8891:lf9:5901 -L 8892:lf9:8080 -L 8893:lab-ctlr3:22 \
        -L 8900:lf10:4002 -L 8901:lf10:5901 -L 8902:lf10:8080 -L 8903:lab-ctlr3:22 \
+       -L 8910:lf11:4002 -L 8911:lf11:5901 -L 8912:lf11:8080 -L 8913:lab-ctlr3:22 \
        -L 8820:lf12:4002 -L 8821:lf12:5901 -L 8822:lf12:8080 -L 8823:lab-ctlr4:22 \
        ubuntu@orch
 
@@ -49,4 +50,12 @@ Testbed 10 (Advanced setup, 2D turntable chamber plus medium chamber, RF attenua
   --ap-jumphost-password pumpkin77 --ap-jumphost-tty /dev/ttyAP2 --lanforge-ip-address localhost --lanforge-port-number 8902 \
   --default-ap-profile TipWlan-2-Radios --sdk-base-url https://wlan-portal-svc.cicd.lab.wlan.tip.build \
   --skip-radius --skip-wpa --verbose --testbed "NOLA-10" --ssid-5g-wpa2 Default-SSID-5gl --psk-5g-wpa2 12345678 \
+  --ssid-2g-wpa2 Default-SSID-2g --psk-2g-wpa2 12345678
+
+Testbed 11 (Advanced setup, 2D turntable chamber plus medium chamber, RF attenuator, etc)
+
+./sdk_set_profile.py --testrail-user-id NONE --model eap102 --ap-jumphost-address localhost --ap-jumphost-port 8913 \
+  --ap-jumphost-password pumpkin77 --ap-jumphost-tty /dev/ttyAP3 --lanforge-ip-address localhost --lanforge-port-number 8912 \
+  --default-ap-profile TipWlan-2-Radios --sdk-base-url https://wlan-portal-svc.cicd.lab.wlan.tip.build \
+  --skip-radius --skip-wpa --verbose --testbed "NOLA-11" --ssid-5g-wpa2 Default-SSID-5gl --psk-5g-wpa2 12345678 \
   --ssid-2g-wpa2 Default-SSID-2g --psk-2g-wpa2 12345678


### PR DESCRIPTION
It is now functional, though it appears eap102 is broken when managed
by cloud at the moment.

Add support for eap102 model to base cmd-line arg parser.

Signed-off-by: Ben Greear <greearb@candelatech.com>