### PR TITLE
[WIFI-3398] Add: kafka and zookeeper resources limits

### DIFF
--- a/helm/ucentral/values.ucentral-qa.yaml
+++ b/helm/ucentral/values.ucentral-qa.yaml
@@ -157,3 +157,22 @@ ucentralfms:
       L+/DtiR5fDVMNdBSGU89UNTi0wHY9+RFuNlIuvZC+x/swF0V9R5mN+ywquTPtDLA
       5IOM7ItsRmen6u3qu+JXros54e4juQ==
       -----END CERTIFICATE-----
+
+kafka:
+  heapOpts: -Xmx512m -Xms512m
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: 200m
+      memory: 700Mi
+  zookeeper:
+    heapSize: 256
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 200m
+        memory: 384Mi


### PR DESCRIPTION
Deployed example of Cloud SDK in `ucentral-test` environment, seems to be working fine - https://grafana.lab.wlan.tip.build/d/85a562078cdf77779eaa1add43ccec1e/kubernetes-compute-resources-namespace-pods?orgId=1&refresh=10s&from=now-15m&to=now&var-datasource=Prometheus&var-cluster=&var-namespace=ucentral-test