### PR TITLE
WIFI-4932: Added test case for getting system info for fms and gw as …

### DIFF
--- a/libs/controller/controller_2x/controller.py
+++ b/libs/controller/controller_2x/controller.py
@@ -184,6 +184,18 @@ class Controller(ConfigureController):
         # resp.close()()
         return version['version']
 
+    def get_system_gw(self):
+        uri = self.build_uri("system/?command=info")
+        resp = requests.get(uri, headers=self.make_headers(), verify=False, timeout=100)
+        self.check_response("GET", resp, self.make_headers(), "", uri)
+        return resp
+
+    def get_system_fms(self):
+        uri = self.build_url_fms("system/?command=info")
+        resp = requests.get(uri, headers=self.make_headers(), verify=False, timeout=100)
+        self.check_response("GET", resp, self.make_headers(), "", uri)
+        return resp
+
     def get_device_uuid(self, serial_number):
         device_info = self.get_device_by_serial_number(serial_number=serial_number)
         return device_info["UUID"]
@@ -556,12 +568,13 @@ class UProfileUtility:
 
 if __name__ == '__main__':
     controller = {
-        'url': 'https://sec-ucentral-qa01.cicd.lab.wlan.tip.build:16001',  # API base url for the controller
+        'url': 'https://sec-qa01.cicd.lab.wlan.tip.build:16001',  # API base url for the controller
         'username': "tip@ucentral.com",
         'password': 'openwifi',
     }
     obj = Controller(controller_data=controller)
-    print(obj.get_sdk_version())
+    print(obj.get_system_fms())
+
     # fms = FMSUtils(sdk_client=obj)
     # new = fms.get_firmwares(model='ecw5410')
     # for i in new:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -262,7 +262,7 @@ def get_sdk_version(fixtures_ver):
 
 # Controller Fixture
 @pytest.fixture(scope="session")
-def setup_controller(request, get_configuration, test_access_point, add_env_properties, fixtures_ver):
+def setup_controller(request, get_configuration, add_env_properties, fixtures_ver):
     """sets up the controller connection and yields the sdk_client object"""
     sdk_client = fixtures_ver.controller_obj
     request.addfinalizer(fixtures_ver.disconnect)
@@ -610,8 +610,12 @@ def add_env_properties(get_configuration, get_sdk_version, get_apnos, fixtures_v
                        add_allure_environment_property: Callable) -> None:
     add_allure_environment_property('Access-Point-Model', get_configuration["access_point"][0]["model"])
     add_allure_environment_property('SDK-Version', get_sdk_version)
-    add_allure_environment_property('Access-Point-Firmware-Version',
-                                    fixtures_ver.get_ap_version(get_apnos, get_configuration)[0].split("\n")[1])
+    try:
+        add_allure_environment_property('Access-Point-Firmware-Version',
+                                        fixtures_ver.get_ap_version(get_apnos, get_configuration)[0].split("\n")[1])
+    except Exception as e:
+        print(e)
+        pass
     add_allure_environment_property('Cloud-Controller-SDK-URL', get_configuration["controller"]["url"])
     add_allure_environment_property('AP-Serial-Number', get_configuration["access_point"][0]["serial"] + "\n")
 

--- a/tests/controller_tests/ucentral_gateway/test_gatewayservice.py
+++ b/tests/controller_tests/ucentral_gateway/test_gatewayservice.py
@@ -236,3 +236,17 @@ class TestUcentralGatewayService(object):
             if resp.status_code != 200:
                 assert False
     '''
+
+    @pytest.mark.system_info_gw
+    def test_system_info_gw(self, setup_controller):
+        system_info = setup_controller.get_system_gw()
+        print(system_info.json())
+        allure.attach(name="system info", body=system_info.json(),attachment_type=allure.attachment_type.JSON)
+        assert system_info.status_code == 200
+
+    @pytest.mark.system_info_gw
+    def test_system_info_fms(self, setup_controller):
+        system_info = setup_controller.get_system_fms()
+        print(system_info.json())
+        allure.attach(name="system info", body=system_info.json(), attachment_type=allure.attachment_type.JSON)
+        assert system_info.status_code == 200


### PR DESCRIPTION
…a part of uc_sanity

Also, added the improvement: controller test can run independently of the AP

Signed-off-by: shivamcandela <shivam.thakur@candelatech.com>