### PR TITLE
add executor info to Allure report task

### DIFF
--- a/.github/actions/generate-allure-report/action.yml
+++ b/.github/actions/generate-allure-report/action.yml
@@ -36,6 +36,21 @@ runs:
         cp -r "${{ inputs.history_path }}" "${{ inputs.results_path }}/history"
       fi
 
+  - name: create executor information
+    shell: bash
+    run: |
+      cat << EOF >> "${{ inputs.results_path }}/executor.json"
+      {
+          "reportName": "${{ github.repository }} ${{ github.workflow }} #${{ github.run_number }}",
+          "buildName": "${{ github.repository }} ${{ github.workflow }} #${{ github.run_number }}",
+          "buildOrder": ${{ github.run_number }},
+          "name": "Github runner",
+          "reportUrl": "../${{ github.run_number }}/index.html",
+          "buildUrl": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+          "type": "github"
+      }
+      EOF
+
   - name: add report metadata
     shell: bash
     run: |
@@ -44,7 +59,7 @@ runs:
       Tests.CommitId=${{ github.sha }}
       CiRun.Id=${{ github.run_id }}
       CiRun.Number=${{ github.run_number }}
-      CiRun.Url=https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      CiRun.Url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
       EOF
 
   - name: generate Allure report


### PR DESCRIPTION
- enables links to previous reports in trend chart