### PR TITLE
WIFI-6814: Adding logic to continue retrieving SSID's incase a cached ID is encountered which is no longer present in the DOM

### DIFF
--- a/libs/perfecto_libs/android_lib.py
+++ b/libs/perfecto_libs/android_lib.py
@@ -2495,7 +2495,10 @@ def get_all_available_ssids(driver, deviceModelName):
             for i in range(len(elements)):
                 # print("elements[i]", elements[i])
                 # print("elements[i].text", elements[i].text)
-                active_ssid_list.append(elements[i].text)
+                try:
+                    active_ssid_list.append(elements[i].text)
+                except:
+                    print("Encountered a cache SSID which is no longer in the DOM.Moving to next SSID.")
         except:
             print("No SSIDS available")
     return active_ssid_list


### PR DESCRIPTION

Signed-off-by: Ajaydeep Grewal <grewal19in@gmail.com>

**Problem**:It seems there are cached SSID’s when we retrieve all the SSID’s elements but when we iterate over them some of them are no longer available as they were cached.

**Solution**: Just catch the error and move on to the next SSID in the iteration.