### PR TITLE
WIFI-6919: Scroll up if unable to verify Pixel WIFI connection

### DIFF
--- a/libs/perfecto_libs/android_lib.py
+++ b/libs/perfecto_libs/android_lib.py
@@ -1635,8 +1635,8 @@ def get_ip_address_and(request, WifiName, WifiPass, setup_perfectoMobile, connDa
                                 print("Wifi Successfully Connected")
                             except NoSuchElementException:
                                 print("Wifi Connection Error: " + WifiName)
-                                closeApp(connData["appPackage-android"], setup_perfectoMobile)
-                                return ip_address_element_text, ssid_with_internet
+                                # closeApp(connData["appPackage-android"], setup_perfectoMobile)
+                                # return ip_address_element_text, ssid_with_internet
                     # -------------------------------------------------------
 
                     # Get into Additional Details
@@ -3420,8 +3420,8 @@ def get_ip_address_eap_and(request, WifiName, User, ttls_passwd, setup_perfectoM
                                 print("Wifi Successfully Connected")
                             except NoSuchElementException:
                                 print("Wifi Connection Error: " + WifiName)
-                                closeApp(connData["appPackage-android"], setup_perfectoMobile)
-                                return ip_address_element_text, ssid_with_internet
+                                # closeApp(connData["appPackage-android"], setup_perfectoMobile)
+                                # return ip_address_element_text, ssid_with_internet
                     # -------------------------------------------------------
 
                     # Get into Additional Details

--- a/libs/perfecto_libs/android_lib.py
+++ b/libs/perfecto_libs/android_lib.py
@@ -1615,6 +1615,8 @@ def get_ip_address_and(request, WifiName, WifiPass, setup_perfectoMobile, connDa
                         check_if_no_internet_popup(driver)
                     except:
                         try:
+                            print("Not able to verify the connected WiFi. Scrolling up.")
+                            scroll_up_pixel(setup_perfectoMobile)
                             check_if_no_internet_popup(driver)
                             WifiInternetErrMsg = WebDriverWait(driver, 35).until(
                                 EC.presence_of_element_located((MobileBy.XPATH,
@@ -3396,6 +3398,8 @@ def get_ip_address_eap_and(request, WifiName, User, ttls_passwd, setup_perfectoM
                         check_if_no_internet_popup(driver)
                     except:
                         try:
+                            print("Not able to verify the connected WiFi. Scrolling up.")
+                            scroll_up_pixel(setup_perfectoMobile)
                             check_if_no_internet_popup(driver)
                             WifiInternetErrMsg = WebDriverWait(driver, 35).until(
                                 EC.presence_of_element_located((MobileBy.XPATH,

--- a/libs/perfecto_libs/android_lib.py
+++ b/libs/perfecto_libs/android_lib.py
@@ -2161,7 +2161,14 @@ def wifi_connect(request, WifiName, WifiPass, setup_perfectoMobile, connData):
                     # -------------------------------------------------------
                     try:
                         report.step_start("Verify if Wifi is Connected")
-                        WifiInternetErrMsg = WebDriverWait(driver, 35).until(
+                        try:
+                            WifiInternetErrMsg = WebDriverWait(driver, 35).until(
+                            EC.presence_of_element_located((MobileBy.XPATH,
+                                                            "//*[@resource-id='android:id/summary' and @text='Connected']/parent::*/android.widget.TextView[@text='" + WifiName + "']")))
+                        except:
+                            print("Not able to verify the connected WiFi. Scrolling up.")
+                            scroll_up_pixel(setup_perfectoMobile)
+                            WifiInternetErrMsg = WebDriverWait(driver, 35).until(
                             EC.presence_of_element_located((MobileBy.XPATH,
                                                             "//*[@resource-id='android:id/summary' and @text='Connected']/parent::*/android.widget.TextView[@text='" + WifiName + "']")))
                         ssid_with_internet = True

--- a/libs/perfecto_libs/android_lib.py
+++ b/libs/perfecto_libs/android_lib.py
@@ -4770,7 +4770,7 @@ def scroll_up_pixel(setup_perfectoMobile):
     print("Scroll up")
     setup_perfectoMobile[1].step_start("Scroll up")
     params2 = {}
-    params2["start"] = "50%,50%"
+    params2["start"] = "50%,20%"
     params2["end"] = "50%,80%"
     params2["duration"] = "4"
     time.sleep(2)

--- a/libs/perfecto_libs/android_lib.py
+++ b/libs/perfecto_libs/android_lib.py
@@ -1618,7 +1618,7 @@ def get_ip_address_and(request, WifiName, WifiPass, setup_perfectoMobile, connDa
                             print("Not able to verify the connected WiFi. Scrolling up.")
                             scroll_up(setup_perfectoMobile)
                             scroll_up(setup_perfectoMobile)
-                            check_if_no_internet_popup(driver)
+                            # check_if_no_internet_popup(driver)
                             WifiInternetErrMsg = WebDriverWait(driver, 35).until(
                                 EC.presence_of_element_located((MobileBy.XPATH,
                                                                 "//*[@resource-id='com.android.settings:id/summary' and @text='Connected without internet']/parent::*/android.widget.TextView[@text='"+ WifiName + "']")))
@@ -1627,16 +1627,17 @@ def get_ip_address_and(request, WifiName, WifiPass, setup_perfectoMobile, connDa
                         except:
                             try:
                                 report.step_start("Verify if Wifi is Connected")
+                                print("Verifying after scrolling")
                                 scroll_up(setup_perfectoMobile)
                                 WifiInternetErrMsg = WebDriverWait(driver, 60).until(EC.presence_of_element_located((
                                     MobileBy.XPATH,
-                                    "//*[@resource-id='com.android.settings:id/summary' and @text='Connected']/parent::*/android.widget.TextView[@text='" + WifiName + "']")))
+                                    "//*[@resource-id='android:id/summary' and @text='Connected']/parent::*/android.widget.TextView[@text='" + WifiName + "']")))
                                 ssid_with_internet = True
                                 print("Wifi Successfully Connected")
                             except NoSuchElementException:
                                 print("Wifi Connection Error: " + WifiName)
-                                # closeApp(connData["appPackage-android"], setup_perfectoMobile)
-                                # return ip_address_element_text, ssid_with_internet
+                                closeApp(connData["appPackage-android"], setup_perfectoMobile)
+                                return ip_address_element_text, ssid_with_internet
                     # -------------------------------------------------------
 
                     # Get into Additional Details
@@ -3415,13 +3416,13 @@ def get_ip_address_eap_and(request, WifiName, User, ttls_passwd, setup_perfectoM
                                 scroll_up(setup_perfectoMobile)
                                 WifiInternetErrMsg = WebDriverWait(driver, 60).until(EC.presence_of_element_located((
                                     MobileBy.XPATH,
-                                    "//*[@resource-id='com.android.settings:id/summary' and @text='Connected']/parent::*/android.widget.TextView[@text='" + WifiName + "']")))
+                                    "//*[@resource-id='android:id/summary' and @text='Connected']/parent::*/android.widget.TextView[@text='" + WifiName + "']")))
                                 ssid_with_internet = True
                                 print("Wifi Successfully Connected")
                             except NoSuchElementException:
                                 print("Wifi Connection Error: " + WifiName)
-                                # closeApp(connData["appPackage-android"], setup_perfectoMobile)
-                                # return ip_address_element_text, ssid_with_internet
+                                closeApp(connData["appPackage-android"], setup_perfectoMobile)
+                                return ip_address_element_text, ssid_with_internet
                     # -------------------------------------------------------
 
                     # Get into Additional Details

--- a/libs/perfecto_libs/android_lib.py
+++ b/libs/perfecto_libs/android_lib.py
@@ -1617,6 +1617,7 @@ def get_ip_address_and(request, WifiName, WifiPass, setup_perfectoMobile, connDa
                         try:
                             print("Not able to verify the connected WiFi. Scrolling up.")
                             scroll_up(setup_perfectoMobile)
+                            scroll_up(setup_perfectoMobile)
                             check_if_no_internet_popup(driver)
                             WifiInternetErrMsg = WebDriverWait(driver, 35).until(
                                 EC.presence_of_element_located((MobileBy.XPATH,
@@ -3401,6 +3402,7 @@ def get_ip_address_eap_and(request, WifiName, User, ttls_passwd, setup_perfectoM
                         try:
                             print("Not able to verify the connected WiFi. Scrolling up.")
                             scroll_up(setup_perfectoMobile)
+                            scroll_up(setup_perfectoMobile)
                             check_if_no_internet_popup(driver)
                             WifiInternetErrMsg = WebDriverWait(driver, 35).until(
                                 EC.presence_of_element_located((MobileBy.XPATH,
@@ -4774,8 +4776,8 @@ def scroll_up(setup_perfectoMobile):
     params2 = {}
     params2["start"] = "50%,20%"
     params2["end"] = "50%,80%"
-    params2["duration"] = "4"
-    time.sleep(2)
+    params2["duration"] = "2"
+    time.sleep(1)
     setup_perfectoMobile[0].execute_script('mobile:touch:swipe', params2)
     time.sleep(1)
 

--- a/libs/perfecto_libs/android_lib.py
+++ b/libs/perfecto_libs/android_lib.py
@@ -1520,7 +1520,7 @@ def get_ip_address_and(request, WifiName, WifiPass, setup_perfectoMobile, connDa
                     # This is To get all available ssids
                     # ------------------------------------------------------
                     try:
-                        for k in range(3):
+                        for k in range(5):
                             available_ssids = get_all_available_ssids(driver, deviceModelName)
                             print("active_ssid_list: ", available_ssids)
                             allure.attach(name="Available SSIDs in device: ", body=str(available_ssids))
@@ -1535,27 +1535,27 @@ def get_ip_address_and(request, WifiName, WifiPass, setup_perfectoMobile, connDa
                                     break
                             except:
                                 print("couldn't find wifi in available ssid")
+                        # if not ssid_found:
+                        #     ssid_not_found = False
+                        #     for k in range(3):
+                        #         try:
+                        #             report.step_start("Selecting Wifi: " + WifiName)
+                        #             wifi_selection_element = WebDriverWait(driver, 35).until(
+                        #                 EC.presence_of_element_located(
+                        #                     (MobileBy.XPATH, "//*[@text='" + WifiName + "']")))
+                        #             wifi_selection_element.click()
+                        #             ssid_not_found = False
+                        #             check_if_no_internet_popup(driver)
+                        #             break
+                        #         except Exception as e:
+                        #             ssid_not_found = True
+                        #             print("Exception on Selecting Wifi Network.  Please check wifi Name or signal")
+                        #         scroll_up_pixel(setup_perfectoMobile)
                         if not ssid_found:
-                            ssid_not_found = False
-                            for k in range(3):
-                                try:
-                                    report.step_start("Selecting Wifi: " + WifiName)
-                                    wifi_selection_element = WebDriverWait(driver, 35).until(
-                                        EC.presence_of_element_located(
-                                            (MobileBy.XPATH, "//*[@text='" + WifiName + "']")))
-                                    wifi_selection_element.click()
-                                    ssid_not_found = False
-                                    check_if_no_internet_popup(driver)
-                                    break
-                                except Exception as e:
-                                    ssid_not_found = True
-                                    print("Exception on Selecting Wifi Network.  Please check wifi Name or signal")
-                                scroll_up_pixel(setup_perfectoMobile)
-                            if ssid_not_found:
-                                print("could not found " + WifiName + " in device")
-                                # allure.attach(name= body=str("could not found" + WifiName + " in device"))
-                                closeApp(connData["appPackage-android"], setup_perfectoMobile)
-                                return ip_address_element_text, ssid_with_internet
+                            print("could not found " + WifiName + " in device")
+                            # allure.attach(name= body=str("could not found" + WifiName + " in device"))
+                            closeApp(connData["appPackage-android"], setup_perfectoMobile)
+                            return ip_address_element_text, ssid_with_internet
                     except:
                         closeApp(connData["appPackage-android"], setup_perfectoMobile)
                         return ip_address_element_text, ssid_with_internet
@@ -1616,7 +1616,7 @@ def get_ip_address_and(request, WifiName, WifiPass, setup_perfectoMobile, connDa
                     except:
                         try:
                             print("Not able to verify the connected WiFi. Scrolling up.")
-                            scroll_up_pixel(setup_perfectoMobile)
+                            scroll_up(setup_perfectoMobile)
                             check_if_no_internet_popup(driver)
                             WifiInternetErrMsg = WebDriverWait(driver, 35).until(
                                 EC.presence_of_element_located((MobileBy.XPATH,
@@ -1626,6 +1626,7 @@ def get_ip_address_and(request, WifiName, WifiPass, setup_perfectoMobile, connDa
                         except:
                             try:
                                 report.step_start("Verify if Wifi is Connected")
+                                scroll_up(setup_perfectoMobile)
                                 WifiInternetErrMsg = WebDriverWait(driver, 60).until(EC.presence_of_element_located((
                                     MobileBy.XPATH,
                                     "//*[@resource-id='com.android.settings:id/summary' and @text='Connected']/parent::*/android.widget.TextView[@text='" + WifiName + "']")))
@@ -3262,7 +3263,7 @@ def get_ip_address_eap_and(request, WifiName, User, ttls_passwd, setup_perfectoM
                     # This is To get all available ssids
                     # ------------------------------------------------------
                     try:
-                        for k in range(3):
+                        for k in range(5):
                             available_ssids = get_all_available_ssids(driver, deviceModelName)
                             print("active_ssid_list: ", available_ssids)
                             allure.attach(name="Available SSIDs in device: ", body=str(available_ssids))
@@ -3277,27 +3278,27 @@ def get_ip_address_eap_and(request, WifiName, User, ttls_passwd, setup_perfectoM
                                     break
                             except:
                                 print("couldn't find wifi in available ssid")
+                        # if not ssid_found:
+                        #     ssid_not_found = False
+                        #     for k in range(3):
+                        #         try:
+                        #             report.step_start("Selecting Wifi: " + WifiName)
+                        #             wifi_selection_element = WebDriverWait(driver, 35).until(
+                        #                 EC.presence_of_element_located(
+                        #                     (MobileBy.XPATH, "//*[@text='" + WifiName + "']")))
+                        #             wifi_selection_element.click()
+                        #             ssid_not_found = False
+                        #             check_if_no_internet_popup(driver)
+                        #             break
+                        #         except Exception as e:
+                        #             ssid_not_found = True
+                        #             print("Exception on Selecting Wifi Network.  Please check wifi Name or signal")
+                        #         scroll_up_pixel(setup_perfectoMobile)
                         if not ssid_found:
-                            ssid_not_found = False
-                            for k in range(3):
-                                try:
-                                    report.step_start("Selecting Wifi: " + WifiName)
-                                    wifi_selection_element = WebDriverWait(driver, 35).until(
-                                        EC.presence_of_element_located(
-                                            (MobileBy.XPATH, "//*[@text='" + WifiName + "']")))
-                                    wifi_selection_element.click()
-                                    ssid_not_found = False
-                                    check_if_no_internet_popup(driver)
-                                    break
-                                except Exception as e:
-                                    ssid_not_found = True
-                                    print("Exception on Selecting Wifi Network.  Please check wifi Name or signal")
-                                scroll_up_pixel(setup_perfectoMobile)
-                            if ssid_not_found:
-                                print("could not found " + WifiName + " in device")
-                                # allure.attach(name= body=str("could not found" + WifiName + " in device"))
-                                closeApp(connData["appPackage-android"], setup_perfectoMobile)
-                                return ip_address_element_text, ssid_with_internet
+                            print("could not found " + WifiName + " in device")
+                            # allure.attach(name= body=str("could not found" + WifiName + " in device"))
+                            closeApp(connData["appPackage-android"], setup_perfectoMobile)
+                            return ip_address_element_text, ssid_with_internet
                     except:
                         closeApp(connData["appPackage-android"], setup_perfectoMobile)
                         return ip_address_element_text, ssid_with_internet
@@ -3399,7 +3400,7 @@ def get_ip_address_eap_and(request, WifiName, User, ttls_passwd, setup_perfectoM
                     except:
                         try:
                             print("Not able to verify the connected WiFi. Scrolling up.")
-                            scroll_up_pixel(setup_perfectoMobile)
+                            scroll_up(setup_perfectoMobile)
                             check_if_no_internet_popup(driver)
                             WifiInternetErrMsg = WebDriverWait(driver, 35).until(
                                 EC.presence_of_element_located((MobileBy.XPATH,
@@ -3409,6 +3410,7 @@ def get_ip_address_eap_and(request, WifiName, User, ttls_passwd, setup_perfectoM
                         except:
                             try:
                                 report.step_start("Verify if Wifi is Connected")
+                                scroll_up(setup_perfectoMobile)
                                 WifiInternetErrMsg = WebDriverWait(driver, 60).until(EC.presence_of_element_located((
                                     MobileBy.XPATH,
                                     "//*[@resource-id='com.android.settings:id/summary' and @text='Connected']/parent::*/android.widget.TextView[@text='" + WifiName + "']")))
@@ -4766,7 +4768,7 @@ def scroll_down_pixel(setup_perfectoMobile):
     time.sleep(2)
     setup_perfectoMobile[0].execute_script('mobile:touch:swipe', params2)
     time.sleep(1)
-def scroll_up_pixel(setup_perfectoMobile):
+def scroll_up(setup_perfectoMobile):
     print("Scroll up")
     setup_perfectoMobile[1].step_start("Scroll up")
     params2 = {}


### PR DESCRIPTION
Signed-off-by: Ajaydeep Grewal <grewal19in@gmail.com>

Have not been able to reproduce the issue.But looking at the test analysis link(https://tip.app.perfectomobile.com/reporting/test/568bdb42-1c73-43d5-a08a-f6184cc93100) it seems the script is not able to verify that the Wifi is connected(although it is connected).

Failure is due to not been able to find the locator: //*[@resource-id='android:id/summary' and @text='Connected']/parent::*/android.widget.TextView[@text='ssid_wpa3_p_m_5g_87K6581']

In the report it seems the ‘connected wifi’ is not visible on the screen(although it should still be in the DOM).

Trying out a fix by scrolling up if we are not able to find the locator.