### PR TITLE
removed regression marker

### DIFF
--- a/tests/e2e/basic/validation_of_operating_modes/nat_mode/rate_limiting/test_rate_limiting.py
+++ b/tests/e2e/basic/validation_of_operating_modes/nat_mode/rate_limiting/test_rate_limiting.py
@@ -5,8 +5,8 @@ Rate LImiting Nat Mode Scenario
 import allure
 import pytest
 
-pytestmark = [pytest.mark.rate_limiting, pytest.mark.nat, pytest.mark.general, pytest.mark.ucentral,
-              pytest.mark.regression]
+# pytestmark = [pytest.mark.rate_limiting, pytest.mark.nat, pytest.mark.general, pytest.mark.ucentral,
+#               pytest.mark.regression]
 
 setup_params_general = {
     "mode": "NAT",

--- a/tests/e2e/basic/validation_of_operating_modes/vlan_mode/rate_limiting/test_rate_limiting.py
+++ b/tests/e2e/basic/validation_of_operating_modes/vlan_mode/rate_limiting/test_rate_limiting.py
@@ -5,8 +5,8 @@ Rate LImiting Vlan Mode Scenario
 import allure
 import pytest
 
-pytestmark = [pytest.mark.rate_limiting, pytest.mark.vlan, pytest.mark.general, pytest.mark.ucentral,
-              pytest.mark.regression]
+# pytestmark = [pytest.mark.rate_limiting, pytest.mark.vlan, pytest.mark.general, pytest.mark.ucentral,
+#               pytest.mark.regression]
 
 setup_params_general = {
     "mode": "VLAN",


### PR DESCRIPTION
Signed-off-by: jitendracandela <jitendra.kushavah@candelatech.com>
removed regression marker from rate_limiting for nat and vlan mode