### PR TITLE
Removed slash at the end of Get API calls

### DIFF
--- a/libs/controller/controller_2x/controller.py
+++ b/libs/controller/controller_2x/controller.py
@@ -173,7 +173,7 @@ class Controller(ConfigureController):
         super().__init__(controller_data)
 
     def get_devices(self):
-        uri = self.build_uri("devices/")
+        uri = self.build_uri("devices")
         print(uri)
         resp = requests.get(uri, headers=self.make_headers(), verify=False, timeout=100)
         self.check_response("GET", resp, self.make_headers(), "", uri)
@@ -651,7 +651,7 @@ class ProvUtils(ConfigureController):
 
 
     def get_venue(self):
-        uri = self.build_url_prov("venue/")
+        uri = self.build_url_prov("venue")
         print(uri)
         resp = requests.get(uri, headers=self.make_headers(), verify=False, timeout=100)
         self.check_response("GET", resp, self.make_headers(), "", uri)


### PR DESCRIPTION
- [x] Removed slash at the end of Get API calls

Signed-off-by: haricharan-jaka <haricharan.jaka@candelatech.com>