### PR TITLE
Changing the QA deployment workflow from v2.7.1-RC2 to main

### DIFF
--- a/.github/workflows/ucentralgw-qa-deployment.yaml
+++ b/.github/workflows/ucentralgw-qa-deployment.yaml
@@ -34,7 +34,7 @@ env:
     {
       "namespace": "qa01",
       "deploy_method": "git",
-      "chart_version": "v2.7.1-RC2",
+      "chart_version": "main",
       "owgw_version": "master",
       "owsec_version": "main",
       "owfms_version": "main",


### PR DESCRIPTION
Changing the QA deployment workflow to main instead of v2.7.1-RC2